### PR TITLE
Adding indirect authordep to Pod::Weaver Contributors plugin

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -56,6 +56,7 @@ meta_noindex = 1        ; respect prior no_index directives
 [MetaYAML]              ; generate META.yml (v1.4)
 [MetaJSON]              ; generate META.json (v2)
 [CPANFile]              ; generate cpanfile
+; authordep Pod::Weaver::Section::Contributors
  
 ; build system
 [ExecDir]           ; include 'bin/*' as executables


### PR DESCRIPTION
`dzil test` and `dzil build` weren't able to run due to `Pod::Weaver::Section::Contributors` being missing.  This module is an indirect dependency for `Dist::Zilla` (since `Pod::Weaver` needs it) and thus needs to be mentioned in the Authordeps section of `dist.ini`.  This looks like the correct location to put this change, if not, please let me know how I should alter the PR so as to fit to your coding style.
