### PR TITLE
Correcting URL to SAX Namespaces website

### DIFF
--- a/README
+++ b/README
@@ -10,7 +10,7 @@ XML::NamespaceSupport
     The model for this module is SAX2's NamespaceSupport class,
     readable at
 
-    http://www.megginson.com/SAX/Java/javadoc/org/xml/sax/helpers/NamespaceSupport.html.
+    http://www.saxproject.org/namespaces.html
 
     It adds a few perlisations where we thought it appropriate, and supports
     the Namespaces in XML 1.1 specification.


### PR DESCRIPTION
As mentioned in RT#68156, the URL pointing to the information about
namespace support has moved.  According to http://www.saxproject.org/ the
webpages at saxproject.org replace those on megginson.com.  This change
updates the README to point to the new location and should close RT#68156.