### PR TITLE
Adding a build config file for Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: perl
+
+perl:
+    - "5.20"
+    - "5.18"
+    - "5.16"
+    - "5.14"
+    - "5.12"
+    - "5.10"
+
+install:
+    - cpanm Dist::Zilla
+    - dzil authordeps --missing | cpanm -n
+    - dzil listdeps --missing | cpanm -n
+
+script:
+    - dzil test --author --release


### PR DESCRIPTION
This change adds a fairly standard Travis-CI configuration file which makes use of `Dist::Zilla` to build and test the distribution.