### PR TITLE
Add tests for untested methods

### DIFF
--- a/lib/XML/NamespaceSupport.pm
+++ b/lib/XML/NamespaceSupport.pm
@@ -144,7 +144,7 @@ sub declare_prefixes {
 sub undeclare_prefix {
     my $self   = shift;
     my $prefix = shift;
-    return unless not defined $prefix or $prefix eq '';
+    return if not defined $prefix or $prefix eq '';
     return unless exists $self->[NSMAP]->[-1]->[PREFIX_MAP]->{$prefix};
 
     my ( $tfix ) = grep { $_ eq $prefix } @{$self->[NSMAP]->[-1]->[DECLARATIONS]};

--- a/t/00base.t
+++ b/t/00base.t
@@ -1,5 +1,5 @@
 use strict;
-use Test::More tests => 59;
+use Test::More tests => 63;
 use XML::NamespaceSupport;
 use constant FATALS       => 0;    # root object
 use constant NSMAP        => 1;
@@ -171,4 +171,22 @@ ok( defined $ns->get_prefix('http://berjon.com') );
     is( $ns->undeclare_prefix(), undef, "undefined prefix" );
     is( $ns->undeclare_prefix(''), undef, "empty prefix" );
     is( $ns->undeclare_prefix('bob'), undef, "nonexistent prefix");
+}
+
+# check parse_jclark_notation with object
+{
+    my $ns = XML::NamespaceSupport->new(
+        { xmlns => 1, fatal_errors => 0, auto_prefix => 1 } );
+    my ($namespace, $local_name) =
+        $ns->parse_jclark_notation('{http://foo}bar');
+    is( $namespace, 'http://foo', "jclark namespace name" );
+    is( $local_name, 'bar', "jclark local name" );
+}
+
+# check parse_jclark_notation without object
+{
+    my ($namespace, $local_name) =
+        XML::NamespaceSupport->parse_jclark_notation('{http://www.cars.com/xml}part');
+    is( $namespace, 'http://www.cars.com/xml', "jclark namespace name" );
+    is( $local_name, 'part', "jclark local name" );
 }

--- a/t/00base.t
+++ b/t/00base.t
@@ -1,5 +1,5 @@
 use strict;
-use Test::More tests => 48;
+use Test::More tests => 52;
 use XML::NamespaceSupport;
 use constant FATALS       => 0;    # root object
 use constant NSMAP        => 1;
@@ -127,3 +127,18 @@ $ns->push_context;
 $ns->declare_prefix( undef, 'http://berjon.com' );
 ok( defined $ns->get_prefix('http://berjon.com') );
 
+# check declare_prefixes()
+{
+    my $ns = XML::NamespaceSupport->new(
+        { xmlns => 1, fatal_errors => 0, auto_prefix => 1 } );
+
+    $ns->push_context;
+    $ns->declare_prefixes(
+        'perl' => 'http://www.perl.com',
+        'java' => 'http://www.java.com'
+    );
+    is( $ns->get_prefix('http://www.perl.com'), 'perl', "prefix from uri" );
+    is( $ns->get_prefix('http://www.java.com'), 'java', "prefix from uri" );
+    is( $ns->get_uri('perl'), 'http://www.perl.com', "uri from prefix" );
+    is( $ns->get_uri('java'), 'http://www.java.com', "uri from prefix" );
+}

--- a/t/00base.t
+++ b/t/00base.t
@@ -1,5 +1,5 @@
 use strict;
-use Test::More tests => 52;
+use Test::More tests => 59;
 use XML::NamespaceSupport;
 use constant FATALS       => 0;    # root object
 use constant NSMAP        => 1;
@@ -141,4 +141,34 @@ ok( defined $ns->get_prefix('http://berjon.com') );
     is( $ns->get_prefix('http://www.java.com'), 'java', "prefix from uri" );
     is( $ns->get_uri('perl'), 'http://www.perl.com', "uri from prefix" );
     is( $ns->get_uri('java'), 'http://www.java.com', "uri from prefix" );
+}
+
+# check undeclare_prefix() with known prefix
+{
+    my $ns = XML::NamespaceSupport->new(
+        { xmlns => 1, fatal_errors => 0, auto_prefix => 1 } );
+
+    $ns->push_context;
+    $ns->declare_prefix('perl', 'http://www.perl.com');
+    $ns->declare_prefix('java', 'http://www.java.com');
+    is( $ns->get_uri('java'), 'http://www.java.com',
+            "prefix defined successfully before undeclare" );
+    $ns->undeclare_prefix('java');
+    isnt( $ns->get_uri('java'), 'http://www.java.com', "prefix undeclared" );
+    is( $ns->get_uri('java'), undef, "prefix undeclared" );
+    is( $ns->get_uri('perl'), 'http://www.perl.com',
+        "untouched prefix still exists");
+}
+
+# check undeclare_prefix() with undefined, empty and nonexistent prefixes
+{
+    my $ns = XML::NamespaceSupport->new(
+        { xmlns => 1, fatal_errors => 0, auto_prefix => 1 } );
+
+    $ns->push_context;
+    $ns->declare_prefix('perl', 'http://www.perl.com');
+    $ns->declare_prefix('java', 'http://www.java.com');
+    is( $ns->undeclare_prefix(), undef, "undefined prefix" );
+    is( $ns->undeclare_prefix(''), undef, "empty prefix" );
+    is( $ns->undeclare_prefix('bob'), undef, "nonexistent prefix");
 }


### PR DESCRIPTION
This PR adds tests for the methods which were not previously covered by the test suite.  In the process of adding these tests, I believe I've found (and fixed) a bug in `undeclare_prefix`.

Each test starts with a fresh object, which doesn't follow the pattern of the existing tests, however I feel it is a good practice for each test to be as self-contained as possible and not dependent upon tests previously run.  If this is undesired for this project, please let me know and I'll update the code and submit an updated PR.

Comments most certainly welcome.  I hope this helps in some way :-)
