### PR TITLE
Correcting error message in declare_prefix()

### DIFF
--- a/lib/XML/NamespaceSupport.pm
+++ b/lib/XML/NamespaceSupport.pm
@@ -111,7 +111,7 @@ sub declare_prefix {
         $self->[NSMAP]->[-1]->[DEFAULT] = $value;
     }
     else {
-        die "Cannot undeclare prefix $prefix" if $value eq '' and not $self->[XMLNS_11];
+        die "Cannot declare prefix $prefix" if $value eq '' and not $self->[XMLNS_11];
         if (not defined $prefix and $self->[AUTO_PREFIX]) {
             while (1) {
                 $prefix = $self->[UNKNOWN_PREF]++;


### PR DESCRIPTION
The error message referred to undeclaring a prefix when the code is trying
to *declare* a prefix.  This change corrects this minor inconsistency.