### PR TITLE
`get_declared_prefixes` should notify user if `push_context` hasn't been used

### DIFF
--- a/lib/XML/NamespaceSupport.pm
+++ b/lib/XML/NamespaceSupport.pm
@@ -187,6 +187,10 @@ sub get_prefixes {
 # get_declared_prefixes() - get all prefixes declared in the last context
 #-------------------------------------------------------------------#
 sub get_declared_prefixes {
+    my $declarations = $_[0]->[NSMAP]->[-1]->[DECLARATIONS];
+    die "At least one context must be pushed onto stack with push_context()\n",
+	"before calling get_declared_prefixes()"
+	if not defined $declarations;
     return @{$_[0]->[NSMAP]->[-1]->[DECLARATIONS]};
 }
 

--- a/lib/XML/NamespaceSupport.pm
+++ b/lib/XML/NamespaceSupport.pm
@@ -458,6 +458,9 @@ Returns an array of all the prefixes that have been declared within
 this context, ie those that were declared on the last element, not
 those that were declared above and are simply in scope.
 
+Note that at least one context must be added to the stack via
+C<push_context> before this method can be called.
+
 =item * $nsup->get_uri($prefix)
 
 Returns a URI for a given prefix. Returns undef on failure.

--- a/t/00base.t
+++ b/t/00base.t
@@ -1,5 +1,5 @@
 use strict;
-use Test::More tests => 48;
+use Test::More tests => 49;
 use XML::NamespaceSupport;
 use constant FATALS       => 0;    # root object
 use constant NSMAP        => 1;
@@ -127,3 +127,10 @@ $ns->push_context;
 $ns->declare_prefix( undef, 'http://berjon.com' );
 ok( defined $ns->get_prefix('http://berjon.com') );
 
+# get_declared_prefixes without context
+{
+    my $ns = XML::NamespaceSupport->new;
+    eval { $ns->get_declared_prefixes };
+    ok( $@ =~ /At least one context/,
+        "get_declared_prefixes raises error without context on stack" );
+}


### PR DESCRIPTION
In RT#2346 a user issue is mentioned whereby calling `push_context()` before calling `get_declared_prefixes()` can be overlooked leading to a "Can't use an undefined value as an ARRAY reference" error.  This PR documents the required behaviour and ensures that the module informs the user that the required call has been missed should `get_declared_prefixes()` be called without having pushed a context onto the stack with `push_context()`.  This PR should therefore close the issue raised in RT#2346.