### PR TITLE
`dist.ini` cleanup

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -101,7 +101,7 @@ default_jobs = 9
 [Git::Commit / Commit_Dirty_Files] ; commit Changes (as released)
 
 [Git::Tag]          ; tag repo with custom tag
-tag_format = release-%v
+tag_format = %v
 
 ; NextRelease acts *during* pre-release to write $VERSION and
 ; timestamp to Changes and  *after* release to add a new {{$NEXT}}

--- a/dist.ini
+++ b/dist.ini
@@ -7,7 +7,7 @@ copyright_year   = 2013
 
 ; version provider
 [Git::NextVersion]  ; get version from last release tag
-version_regexp = ^release-(.+)$
+version_regexp = ^(\d+\.\d+)$
 
 ; collect contributors list
 [ContributorsFromGit]

--- a/dist.ini
+++ b/dist.ini
@@ -3,7 +3,7 @@ author  = Robin Berjon <robin@knowscape.com>
 author  = Chris Prather <chris@prather.org>
 license = Perl_5
 copyright_holder = Robin Berjon
-copyright_year   = 2013
+copyright_year   = 2015
 
 ; version provider
 [Git::NextVersion]  ; get version from last release tag

--- a/dist.ini
+++ b/dist.ini
@@ -8,110 +8,110 @@ copyright_year   = 2013
 ; version provider
 [Git::NextVersion]  ; get version from last release tag
 version_regexp = ^release-(.+)$
- 
+
 ; collect contributors list
 [ContributorsFromGit]
- 
+
 ; choose files to include
 [Git::GatherDir]         ; everything from git ls-files
 exclude_filename = cpanfile     ; skip this generated file
- 
+
 [PruneCruft]        ; default stuff to skip
 [ManifestSkip]      ; if -f MANIFEST.SKIP, skip those, too
- 
+
 ; file modifications
 [OurPkgVersion]     ; add $VERSION = ... to all files
 [InsertCopyright]   ; add copyright at "# COPYRIGHT"
 [PodWeaver]         ; generate Pod
- 
+
 ; generated files
 [License]           ; boilerplate license
- 
+
 ; metadata
 [AutoPrereqs]       ; find prereqs from code
 skip = ^t::lib
- 
+
 [Authority]
 authority = cpan:PERIGRIN
 do_munging = 0
- 
+
 [MinimumPerl]   ; determine minimum perl version
- 
+
 [MetaNoIndex]       ; sets 'no_index' in META
 directory = t
 directory = xt
 directory = examples
 directory = corpus
 package = DB        ; just in case
- 
+
 [GithubMeta]        ; set META resources
 remote = origin
 remote = github
 issues = 1
- 
+
 [MetaProvides::Package] ; add 'provides' to META files
 meta_noindex = 1        ; respect prior no_index directives
- 
+
 [Prereqs::AuthorDeps]   ; add authordeps as develop/requires
 [MetaYAML]              ; generate META.yml (v1.4)
 [MetaJSON]              ; generate META.json (v2)
 [CPANFile]              ; generate cpanfile
- 
+
 ; build system
 [ExecDir]           ; include 'bin/*' as executables
 [ShareDir]          ; include 'share/' for File::ShareDir
 [MakeMaker]         ; create Makefile.PL
 eumm_version = 6.17
 default_jobs = 9
- 
+
 ; manifest (after all generated files)
 [Manifest]          ; create MANIFEST
- 
+
 ; copy cpanfile back to repo dis
 [CopyFilesFromBuild]
 copy = cpanfile
- 
+
 ; before release
- 
+
 [PromptIfStale]     ; check if our build tools are out of date
 module = Dist::Zilla
 check_all_plugins = 1
- 
+
 [Git::CheckFor::CorrectBranch] ; ensure on master branch
- 
+
 [Git::Check]        ; ensure all files checked in
 allow_dirty = dist.ini
 allow_dirty = Changes
 allow_dirty = cpanfile
- 
+
 [CheckMetaResources]     ; ensure META has 'resources' data
 [CheckPrereqsIndexed]    ; ensure prereqs are on CPAN
 [CheckChangesHasContent] ; ensure Changes has been updated
- 
+
 [RunExtraTests]   ; ensure xt/ tests pass
 default_jobs = 9
- 
+
 [TestRelease]       ; ensure t/ tests pass
 [ConfirmRelease]    ; prompt before uploading
- 
+
 ; releaser
 [UploadToCPAN]      ; uploads to CPAN
- 
+
 ; after release
 [Git::Commit / Commit_Dirty_Files] ; commit Changes (as released)
- 
+
 [Git::Tag]          ; tag repo with custom tag
 tag_format = release-%v
- 
+
 ; NextRelease acts *during* pre-release to write $VERSION and
 ; timestamp to Changes and  *after* release to add a new {{$NEXT}}
 ; section, so to act at the right time after release, it must actually
 ; come after Commit_Dirty_Files but before Commit_Changes in the
 ; dist.ini.  It will still act during pre-release as usual
- 
+
 [NextRelease]
- 
+
 [Git::Commit / Commit_Changes] ; commit Changes (for new dev)
- 
+
 [Git::Push]         ; push repo to remote
 push_to = origin


### PR DESCRIPTION
This PR tidies up some minor issues with the `dist.ini` file. The most controversial of the changes is the change to the version regexp used to match the relevant release tag name; I might have implemented a regexp which is too specific and thus not flexible enough to handle possible future release tag names.  If another regexp is more appropriate, please let me know and I'll update the PR accordingly.

As usual, any comments welcome!